### PR TITLE
Add support for PVC retain, debuging via command override

### DIFF
--- a/ollama/Chart.yaml
+++ b/ollama/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ollama/templates/deployment.yaml
+++ b/ollama/templates/deployment.yaml
@@ -18,17 +18,30 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.commandOverride }}
+          command: 
+            - {{ .Values.commandOverride.command }}
+          args: 
+            {{- range .Values.commandOverride.args }}
+            - "{{ . }}"
+            {{- end }}
+          {{- end }}
           ports:
             - containerPort: 11434
-          {{- if .Values.persistence.enabled }}
           volumeMounts:
+            - name: temp
+              mountPath: /tmp
+          {{- if .Values.persistence.enabled }}
             - name: ollama-storage
               mountPath: /root/.ollama
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if .Values.persistence.enabled }}
       volumes:
+        - name: temp
+          emptyDir:
+            sizeLimit: 1G
+      {{- if .Values.persistence.enabled }}
         - name: ollama-storage
           persistentVolumeClaim:
             claimName: {{ include "ollama.fullname" . }}

--- a/ollama/templates/pvc.yaml
+++ b/ollama/templates/pvc.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "ollama.fullname" . }}
+  {{- if .Values.persistence.retain }}
+  annotations:
+    "helm.sh/resource-policy": "keep"
+  {{- end }}
   labels:
     {{- include "ollama.labels" . | nindent 4 }}
 spec:

--- a/ollama/values.yaml
+++ b/ollama/values.yaml
@@ -16,8 +16,13 @@ persistence:
   storageClass: ""
   accessMode: ReadWriteOnce
   size: 50Gi
+  retain: true
 
 resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+commandOverride:
+  enabled: false
+  command: /bin/true
+  args: []


### PR DESCRIPTION
A couple of options added

* add command override to allow to exec and DEBUG
* add retain feature on the model PVC to avoid having to re-download models after re-deploy